### PR TITLE
Automatic GetResult for a HList

### DIFF
--- a/src/main/scala/main.scala
+++ b/src/main/scala/main.scala
@@ -14,6 +14,10 @@ object Example extends App {
     def email = column[String]("email")
 
     def * = (id :: email :: HNil)
+
+    implicit class AnyOps[A](a: A) {
+      def some: Option[A] = Some(a)
+    }
   }
 
   lazy val users = TableQuery[Users]
@@ -29,6 +33,12 @@ object Example extends App {
   // Query to see what's in the database:
   val result = Await.result(db.run(users.result), 2 seconds)
   println(s"Result of action is: $result")
+
+  // Going to a case class from an HList:
+  case class SomeCaseClass(id: Long, email: String)
+  val gen = Generic[SomeCaseClass]
+  val caseClasses = result.map(gen.from)
+  println(s"As a case class: $caseClasses")
 
   db.close
 }

--- a/src/main/scala/main.scala
+++ b/src/main/scala/main.scala
@@ -40,5 +40,18 @@ object Example extends App {
   val caseClasses = result.map(gen.from)
   println(s"As a case class: $caseClasses")
 
+  // GetResult type class
+  import slick.jdbc.GetResult
+  implicit val getResults: GetResult[SomeCaseClass] =
+    GetResult(r => SomeCaseClass(id = r.nextLong, email = r.nextString))
+
+  // NB: in place of nextLong and nextString we can use r.<< for both
+
+  val plainSql =
+    sql""" select "id", "email" from "users" """.as[SomeCaseClass]
+
+  val plainSqlResults = Await.result(db.run(plainSql), 2 seconds)
+  println(s"Plain SQL GenResult: $plainSqlResults")
+
   db.close
 }


### PR DESCRIPTION
When using a feature of Slick called Plain SQL, if you want to get an HList back from a plain SQL, the invocation looks like this:

``` scala
val plainSql =
    sql""" select "id", "email" from "users" """.as[Long :: String :: HNil]
```

For that to work, though, there’s a type class that needs an implementation. Specifically, `GetResult[Long :: String :: HNil]`.

This PR adds two implicits that will create a `GetResult` for you.
